### PR TITLE
Fixed a bug that happens when plugin is loaded

### DIFF
--- a/src/components/App.lua
+++ b/src/components/App.lua
@@ -66,7 +66,6 @@ function component:render()
 			e.Pane {
 				Size = UDim2.new(1, 0, 1, 0);
 			};
-			e.Welcome();
 			e.BeginLink();
 			e.CheckLink();
 			e.Refresh();
@@ -78,6 +77,7 @@ function component:render()
 			e.Generate_Params();
 			e.Messages();
 			e.Confirmation();
+			e.Welcome();
 		})
 	})
 end


### PR DESCRIPTION
There is a bug caused by the confirmation page being loaded after the welcome page. Thus causing it to slide to the right when plugin loads. This fixes it.